### PR TITLE
Remove use of waitable timer, switch to busy wait

### DIFF
--- a/trashim/TRAWindowed.cpp
+++ b/trashim/TRAWindowed.cpp
@@ -253,11 +253,8 @@ namespace trashim
     {
         LARGE_INTEGER current_time;
         QueryPerformanceCounter(&current_time);
-
         int64_t difference = current_time.QuadPart - timer_previous;
-
-        auto difference_in_seconds = static_cast<float>(difference) / timer_frequency;
-        return difference_in_seconds * 1e7;
+        return (static_cast<double>(difference) / timer_frequency) * 1e7;
     }
 
     void wait_for_frame()


### PR DESCRIPTION
Waitable timer doesn't have the resolution required to reliably keep the framerate stable.
Switch to a busy wait that just repeatedly polls the high performance counter.
Closes #3