### PR TITLE
Allow toggling mouse capture and fix Action! tiny windows

### DIFF
--- a/trashim/ShimDirect3D9.cpp
+++ b/trashim/ShimDirect3D9.cpp
@@ -2,13 +2,58 @@
 #include "ShimDirect3D9.h"
 #include "ShimDirect3DDevice9.h"
 #include "TRAWindowed.h"
+#include <intrin.h>
+#include <tlhelp32.h>
+#include <tuple>
+
+#pragma intrinsic(_ReturnAddress)
+
+namespace
+{
+    std::tuple<uint32_t, uint32_t> get_action_range(HANDLE action)
+    {
+        HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE32 | TH32CS_SNAPMODULE, GetProcessId(GetCurrentProcess()));
+        MODULEENTRY32W entry;
+        entry.dwSize = sizeof(entry);
+        if (Module32First(snapshot, &entry))
+        {
+            do
+            {
+                if (entry.hModule == action)
+                {
+                    CloseHandle(snapshot);
+                    return { reinterpret_cast<uint32_t>(entry.modBaseAddr), reinterpret_cast<uint32_t>(entry.modBaseAddr) + entry.modBaseSize };
+                }
+            } while (Module32Next(snapshot, &entry));
+        }
+        CloseHandle(snapshot);
+        return { 0, 0 };
+    }
+
+    bool should_initialise_shim(void* caller)
+    {
+        HANDLE action = GetModuleHandle(L"action_x86.dll");
+        if (action == INVALID_HANDLE_VALUE)
+        {
+            return true;
+        }
+        auto range = get_action_range(action);
+        uint32_t return_address = reinterpret_cast<uint32_t>(caller);
+        return return_address < std::get<0>(range) || return_address > std::get<1>(range);
+    }
+}
 
 HRESULT ShimDirect3D9::CreateDevice(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface)
 {
     D3DDISPLAYMODE mode;
     _d3d9->GetAdapterDisplayMode(Adapter, &mode);
 
-    trashim::initialise_shim(hFocusWindow, pPresentationParameters->BackBufferWidth, pPresentationParameters->BackBufferHeight, mode.Width, mode.Height, pPresentationParameters->PresentationInterval != D3DPRESENT_INTERVAL_IMMEDIATE, pPresentationParameters->FullScreen_RefreshRateInHz);
+    OutputDebugString(L"Create device called\n");
+
+    if (should_initialise_shim(_ReturnAddress()))
+    {
+        trashim::initialise_shim(hFocusWindow, pPresentationParameters->BackBufferWidth, pPresentationParameters->BackBufferHeight, mode.Width, mode.Height, pPresentationParameters->PresentationInterval != D3DPRESENT_INTERVAL_IMMEDIATE, pPresentationParameters->FullScreen_RefreshRateInHz);
+    }
 
     pPresentationParameters->Windowed = TRUE;
     pPresentationParameters->FullScreen_RefreshRateInHz = 0;

--- a/trashim/ShimDirect3D9.cpp
+++ b/trashim/ShimDirect3D9.cpp
@@ -2,55 +2,13 @@
 #include "ShimDirect3D9.h"
 #include "ShimDirect3DDevice9.h"
 #include "TRAWindowed.h"
-#include <intrin.h>
-#include <tlhelp32.h>
-#include <tuple>
-
-#pragma intrinsic(_ReturnAddress)
-
-namespace
-{
-    std::tuple<uint32_t, uint32_t> get_action_range(HANDLE action)
-    {
-        HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE32 | TH32CS_SNAPMODULE, GetProcessId(GetCurrentProcess()));
-        MODULEENTRY32W entry;
-        entry.dwSize = sizeof(entry);
-        if (Module32First(snapshot, &entry))
-        {
-            do
-            {
-                if (entry.hModule == action)
-                {
-                    CloseHandle(snapshot);
-                    return { reinterpret_cast<uint32_t>(entry.modBaseAddr), reinterpret_cast<uint32_t>(entry.modBaseAddr) + entry.modBaseSize };
-                }
-            } while (Module32Next(snapshot, &entry));
-        }
-        CloseHandle(snapshot);
-        return { 0, 0 };
-    }
-
-    bool should_initialise_shim(void* caller)
-    {
-        HANDLE action = GetModuleHandle(L"action_x86.dll");
-        if (action == INVALID_HANDLE_VALUE)
-        {
-            return true;
-        }
-        auto range = get_action_range(action);
-        uint32_t return_address = reinterpret_cast<uint32_t>(caller);
-        return return_address < std::get<0>(range) || return_address > std::get<1>(range);
-    }
-}
 
 HRESULT ShimDirect3D9::CreateDevice(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface)
 {
     D3DDISPLAYMODE mode;
     _d3d9->GetAdapterDisplayMode(Adapter, &mode);
 
-    OutputDebugString(L"Create device called\n");
-
-    if (should_initialise_shim(_ReturnAddress()))
+    if (hFocusWindow)
     {
         trashim::initialise_shim(hFocusWindow, pPresentationParameters->BackBufferWidth, pPresentationParameters->BackBufferHeight, mode.Width, mode.Height, pPresentationParameters->PresentationInterval != D3DPRESENT_INTERVAL_IMMEDIATE, pPresentationParameters->FullScreen_RefreshRateInHz);
     }

--- a/trashim/TRAWindowed.cpp
+++ b/trashim/TRAWindowed.cpp
@@ -13,11 +13,6 @@ namespace trashim
         bool mouse_captured{ false };
         bool capture_allowed{ true };
 
-        bool is_mouse_captured()
-        {
-            return mouse_captured & capture_allowed;
-        }
-
         // Style used to toggle on and off the bordered windowed mode.
         const LONG_PTR windowed_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
 

--- a/trashim/TRAWindowed.cpp
+++ b/trashim/TRAWindowed.cpp
@@ -11,6 +11,12 @@ namespace trashim
         // Whether or not to capture the mouse when the cursor is moved (apply a clip rectangle).
         // This is disabled when the window has lost focus.
         bool mouse_captured{ false };
+        bool capture_allowed{ true };
+
+        bool is_mouse_captured()
+        {
+            return mouse_captured & capture_allowed;
+        }
 
         // Style used to toggle on and off the bordered windowed mode.
         const LONG_PTR windowed_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
@@ -137,7 +143,7 @@ namespace trashim
         void capture_mouse()
         {
             // Allow the user to give control
-            if (!mouse_captured)
+            if (!mouse_captured && capture_allowed)
             {
                 mouse_captured = true;
                 while (ShowCursor(false) >= 0) {}
@@ -172,6 +178,19 @@ namespace trashim
             }
         }
 
+        void toggle_capture()
+        {
+            capture_allowed = !capture_allowed;
+            if (capture_allowed)
+            {
+                capture_mouse();
+            }
+            else
+            {
+                release_mouse();
+            }
+        }
+
         void initialise_timer()
         {
             LARGE_INTEGER frequency;
@@ -203,6 +222,10 @@ namespace trashim
                     else if (wParam == VK_F6)
                     {
                         toggle_on_top();
+                    }
+                    else if (wParam == VK_F8)
+                    {
+                        toggle_capture();
                     }
                     break;
                 }

--- a/trashim/trashim.vcxproj
+++ b/trashim/trashim.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -73,6 +73,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <TargetName>d3d9</TargetName>
+    <OutDir>D:\Games\Steam\steamapps\common\Tomb Raider Anniversary</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -95,6 +96,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;TRASHIM_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)/detours/include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Allow the user to toggle mouse capture using the F8 button.
Only init when the D3D create device call has a focus window. If the focus window is 0 then it hasn't come from the game. Action! was creating a device with a small resolution (not focused on a window) and the shim was being reinitialised and resized to this new small size.
Closes #12 
Closes #11 