### PR TITLE
Add required resolutions even if not supported by adapter

### DIFF
--- a/trashim/ShimDirect3D9.cpp
+++ b/trashim/ShimDirect3D9.cpp
@@ -8,6 +8,8 @@ namespace
 {
     std::unordered_map<UINT, std::vector<D3DDISPLAYMODE>> adapter_display_modes;
 
+    const std::vector<UINT> wanted_refresh_rates{ 20, 30, 40, 50, 60, 70, 75, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200 };
+
     std::vector<D3DDISPLAYMODE> store_display_modes(IDirect3D9& d3d9, UINT adapter, D3DFORMAT format)
     {
         auto found = adapter_display_modes.find(adapter);
@@ -27,8 +29,26 @@ namespace
 
         // TODO: Find the missing framerates - we want to provide 20-200
         // TODO: Add the missing framerates.
+        for (auto rate : wanted_refresh_rates)
+        {
+            bool found = false;
+            for (const auto& mode : modes)
+            {
+                if (mode.Width == 1024 && mode.Height == 768 && mode.RefreshRate == rate)
+                {
+                    found = true;
+                    break;
+                }
+            }
 
-        adapter_display_modes.insert({ adapter, modes });
+            if (!found)
+            {
+                modes.push_back(D3DDISPLAYMODE{ 1024, 768, rate, format });
+            }
+        }
+
+        adapter_display_modes[adapter] = modes;
+        return modes;
     }
 }
 

--- a/trashim/ShimDirect3D9.cpp
+++ b/trashim/ShimDirect3D9.cpp
@@ -31,7 +31,7 @@ namespace
 {
     std::unordered_map<UINT, std::vector<D3DDISPLAYMODE>> adapter_display_modes;
 
-    const std::vector<UINT> wanted_refresh_rates{ 20, 40, 60, 100, 144, 200 };
+    const std::vector<UINT> wanted_refresh_rates{ 20, 40, 60, 100, 144 };
 
     std::vector<D3DDISPLAYMODE> store_display_modes(IDirect3D9& d3d9, UINT adapter, D3DFORMAT format)
     {

--- a/trashim/ShimDirect3D9.cpp
+++ b/trashim/ShimDirect3D9.cpp
@@ -2,6 +2,35 @@
 #include "ShimDirect3D9.h"
 #include "ShimDirect3DDevice9.h"
 #include "TRAWindowed.h"
+#include <unordered_map>
+
+namespace
+{
+    std::unordered_map<UINT, std::vector<D3DDISPLAYMODE>> adapter_display_modes;
+
+    std::vector<D3DDISPLAYMODE> store_display_modes(IDirect3D9& d3d9, UINT adapter, D3DFORMAT format)
+    {
+        auto found = adapter_display_modes.find(adapter);
+        if (adapter_display_modes.find(adapter) != adapter_display_modes.end())
+        {
+            return found->second;
+        }
+
+        std::vector<D3DDISPLAYMODE> modes;
+        uint32_t actual_count = d3d9.GetAdapterModeCount(adapter, format);
+        for (uint32_t i = 0; i < actual_count; ++i)
+        {
+            D3DDISPLAYMODE mode {};
+            d3d9.EnumAdapterModes(adapter, format, i, &mode);
+            modes.push_back(mode);
+        }
+
+        // TODO: Find the missing framerates - we want to provide 20-200
+        // TODO: Add the missing framerates.
+
+        adapter_display_modes.insert({ adapter, modes });
+    }
+}
 
 HRESULT ShimDirect3D9::CreateDevice(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface)
 {
@@ -23,3 +52,15 @@ HRESULT ShimDirect3D9::CreateDevice(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, H
     return hr;
 }
 
+UINT ShimDirect3D9::GetAdapterModeCount(UINT Adapter, D3DFORMAT Format)
+{
+    auto modes = store_display_modes(*_d3d9, Adapter, Format);
+    return modes.size();
+}
+
+HRESULT ShimDirect3D9::EnumAdapterModes(UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE* pMode)
+{
+    auto modes = store_display_modes(*_d3d9, Adapter, Format);
+    *pMode = modes[Mode];
+    return D3D_OK;
+}

--- a/trashim/ShimDirect3D9.h
+++ b/trashim/ShimDirect3D9.h
@@ -52,15 +52,8 @@ struct ShimDirect3D9 : IDirect3D9
         return _d3d9->GetAdapterIdentifier(Adapter, Flags, pIdentifier);
     }
 
-    STDMETHOD_(UINT, GetAdapterModeCount)(THIS_ UINT Adapter, D3DFORMAT Format)
-    {
-        return _d3d9->GetAdapterModeCount(Adapter, Format);
-    }
-
-    STDMETHOD(EnumAdapterModes)(THIS_ UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE* pMode)
-    {
-        return _d3d9->EnumAdapterModes(Adapter, Format, Mode, pMode);
-    }
+    STDMETHOD_(UINT, GetAdapterModeCount)(THIS_ UINT Adapter, D3DFORMAT Format);
+    STDMETHOD(EnumAdapterModes)(THIS_ UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE* pMode);
 
     STDMETHOD(GetAdapterDisplayMode)(THIS_ UINT Adapter, D3DDISPLAYMODE* pMode)
     {

--- a/trashim/resource.h
+++ b/trashim/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by trashim.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/trashim/trashim.rc
+++ b/trashim/trashim.rc
@@ -67,7 +67,7 @@ BEGIN
     BEGIN
         BLOCK "080904b0"
         BEGIN
-            VALUE "CompanyName", "chreden"
+            VALUE "CompanyName", "https://github.com/chreden/trawindowed"
             VALUE "FileDescription", "Windowed DLL for TR LAU"
             VALUE "FileVersion", "1.4.0.0"
             VALUE "InternalName", "d3d9.dll"

--- a/trashim/trashim.rc
+++ b/trashim/trashim.rc
@@ -1,0 +1,100 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United Kingdom) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 1,4,0,0
+ PRODUCTVERSION 1,4,0,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "080904b0"
+        BEGIN
+            VALUE "CompanyName", "chreden"
+            VALUE "FileDescription", "Windowed DLL for TR LAU"
+            VALUE "FileVersion", "1.4.0.0"
+            VALUE "InternalName", "d3d9.dll"
+            VALUE "LegalCopyright", "Copyright (C) 2022"
+            VALUE "OriginalFilename", "d3d9.dll"
+            VALUE "ProductName", "chreden/trawindowed"
+            VALUE "ProductVersion", "1.4.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x809, 1200
+    END
+END
+
+#endif    // English (United Kingdom) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/trashim/trashim.vcxproj
+++ b/trashim/trashim.vcxproj
@@ -135,6 +135,7 @@
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)/detours/include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trashim/trashim.vcxproj
+++ b/trashim/trashim.vcxproj
@@ -171,6 +171,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="resource.h" />
     <ClInclude Include="ShimDirect3DDevice9.h" />
     <ClInclude Include="TRAWindowed.h" />
     <ClInclude Include="ShimDirect3D9.h" />
@@ -192,6 +193,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="trashim.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="trashim.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/trashim/trashim.vcxproj.filters
+++ b/trashim/trashim.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="ShimDirect3DDevice9.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -55,5 +58,10 @@
     <None Include="trashim.def">
       <Filter>Source Files</Filter>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="trashim.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Some runs require certain framerates however LAU will only show resolutions and refresh rates that the display adapter supports at fullscreen.
If running in windowed report that the device can support 20, 40, 60, 144 and 200 hz even if it can't. Since we are running windowed it doesn't matter as it will all be done with the framerate emulation.
Add a version to the DLL and set it to 1.4.0.0
Closes #16 