### PR TITLE
Add -borderless command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a custom d3d9.dll that enables more display modes for the three second e
 
 ### Switch display modes
 1. Start the game
-2. Press F5 to switch the mode
+2. Press F5 to switch between bordered and borderless windowed mode.
 
 ### Toggle Always on Top
 1. Start the game
@@ -25,6 +25,9 @@ This is a custom d3d9.dll that enables more display modes for the three second e
 2. Press F8 to toggle mouse capture.
 
 This can be useful if you want to interact with the TRAE Menu Hook.
+
+### Command Line Arguments
+Passing `-borderless` to the game exe will launch the game in borderless window mode (as if you had started the game and pressed the toggle button). This can be set via "Launch Options" in Steam.
 
 ## Information for developers
 ### Build

--- a/trashim/trashim.rc
+++ b/trashim/trashim.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,4,0,0
- PRODUCTVERSION 1,4,0,0
+ FILEVERSION 1,5,0,0
+ PRODUCTVERSION 1,5,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "https://github.com/chreden/trawindowed"
             VALUE "FileDescription", "Windowed DLL for TR LAU"
-            VALUE "FileVersion", "1.4.0.0"
+            VALUE "FileVersion", "1.5.0.0"
             VALUE "InternalName", "d3d9.dll"
-            VALUE "LegalCopyright", "Copyright (C) 2022"
+            VALUE "LegalCopyright", "Copyright (C) 2024"
             VALUE "OriginalFilename", "d3d9.dll"
             VALUE "ProductName", "chreden/trawindowed"
-            VALUE "ProductVersion", "1.4.0.0"
+            VALUE "ProductVersion", "1.5.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
If user passes `-borderless` to the game exe start with borderless mode enabled.
Steam Deck doesn't have a keyboard so it is helpful here.
#20