### PR TITLE
Optionally disable GetCursorPos ScreenToClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This can be useful if you want to interact with the TRAE Menu Hook.
 
 ### Command Line Arguments
 Passing `-borderless` to the game exe will launch the game in borderless window mode (as if you had started the game and pressed the toggle button). This can be set via "Launch Options" in Steam.
+Passing `-camerafix` to the game exe will fix an issue with the camera (if it gets stuck looking down). This can be set via "Launch Options" in Steam.
 
 ## Information for developers
 ### Build

--- a/trashim/trashim.rc
+++ b/trashim/trashim.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,5,0,0
- PRODUCTVERSION 1,5,0,0
+ FILEVERSION 1,6,0,0
+ PRODUCTVERSION 1,6,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "https://github.com/chreden/trawindowed"
             VALUE "FileDescription", "Windowed DLL for TR LAU"
-            VALUE "FileVersion", "1.5.0.0"
+            VALUE "FileVersion", "1.6.0.0"
             VALUE "InternalName", "d3d9.dll"
             VALUE "LegalCopyright", "Copyright (C) 2024"
             VALUE "OriginalFilename", "d3d9.dll"
             VALUE "ProductName", "chreden/trawindowed"
-            VALUE "ProductVersion", "1.5.0.0"
+            VALUE "ProductVersion", "1.6.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Add a new command line argument `-camerafix` to disable the `ScreenToClient` call inside GetCursorPos. It seems that on Windows 11 this is causing the camera to point down all the time.
Closes #22