### PR TITLE
Change hotkeys from F5/56 to F6/F7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ This is a custom d3d9.dll that enables more display modes for the three second e
 
 ### Switch display modes
 1. Start the game
-2. Press F5 to switch between bordered and borderless windowed mode.
+2. Press F6 to switch between bordered and borderless windowed mode.
 
 ### Center the window
 1. Start the game
-2. Press Shift + F5 to center the window on the monitor the window is currently on.
+2. Press Shift + F6 to center the window on the monitor the window is currently on.
 
 ### Toggle Always on Top
 1. Start the game
-2. Press F6 to toggle always on top
+2. Press F7 to toggle always on top
 
 ### Toggle mouse capture
 1. Start the game

--- a/trashim/TRAWindowed.cpp
+++ b/trashim/TRAWindowed.cpp
@@ -247,7 +247,7 @@ namespace trashim
             {
                 case WM_KEYDOWN:
                 {
-                    if (wParam == VK_F5)
+                    if (wParam == VK_F6)
                     {
                         if (GetKeyState(VK_SHIFT) & 0x8000)
                         {
@@ -258,7 +258,7 @@ namespace trashim
                             toggle_border();
                         }
                     }
-                    else if (wParam == VK_F6)
+                    else if (wParam == VK_F7)
                     {
                         toggle_on_top();
                     }

--- a/trashim/trashim.rc
+++ b/trashim/trashim.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,0,0
- PRODUCTVERSION 1,8,0,0
+ FILEVERSION 1,9,0,0
+ PRODUCTVERSION 1,9,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "https://github.com/chreden/trawindowed"
             VALUE "FileDescription", "Windowed DLL for TR LAU"
-            VALUE "FileVersion", "1.8.0.0"
+            VALUE "FileVersion", "1.9.0.0"
             VALUE "InternalName", "d3d9.dll"
             VALUE "LegalCopyright", "Copyright (C) chreden 2025"
             VALUE "OriginalFilename", "d3d9.dll"
             VALUE "ProductName", "chreden/trawindowed"
-            VALUE "ProductVersion", "1.8.0.0"
+            VALUE "ProductVersion", "1.9.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Move some hotkeys around to avoid clashes with the menu hook.

- Move the border/centre keys from F5/Ctrl+F5 to F6/Ctrl+F6
- Move on top from F6 to F7

Update version to 1.9.

#32 